### PR TITLE
fix: useSnackbar cannot use in develop mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from "@material-ui/core/styles";
 import "./App.css";
 import RelayEnvironment from "./RelayEnvironment";
 import GraphQLQueryClientContextProvider from "./context/QueryClientContext";
+import SnackbarProvider from "./context/SnackbarContext";
 import { Routes } from "./routes";
 import replyTheme from "./theme/replyTheme";
 
@@ -21,13 +22,15 @@ function AppRoot() {
             <ThemeProvider theme={replyTheme}>
                 <RelayEnvironmentProvider environment={RelayEnvironment}>
                     <QueryClientProvider client={queryClient}>
-                        <GraphQLQueryClientContextProvider>
-                            <Suspense fallback={<CircularProgress />}>
-                                <BrowserRouter>
-                                    <Routes />
-                                </BrowserRouter>
-                            </Suspense>
-                        </GraphQLQueryClientContextProvider>
+                        <SnackbarProvider>
+                            <GraphQLQueryClientContextProvider>
+                                <Suspense fallback={<CircularProgress />}>
+                                    <BrowserRouter>
+                                        <Routes />
+                                    </BrowserRouter>
+                                </Suspense>
+                            </GraphQLQueryClientContextProvider>
+                        </SnackbarProvider>
                     </QueryClientProvider>
                 </RelayEnvironmentProvider>
             </ThemeProvider>

--- a/src/components/Alerts/AlertBase/index.tsx
+++ b/src/components/Alerts/AlertBase/index.tsx
@@ -4,8 +4,8 @@ import { Alert as MaterialAlert, AlertProps as MaterialAlertProps } from "@mater
 
 export interface AlertBaseProps extends MaterialAlertProps {}
 
-const AlertBase = (props: AlertBaseProps) => {
-    return <MaterialAlert {...props} />;
-};
+const AlertBase = React.forwardRef(function AlertBase(props: AlertBaseProps, ref) {
+    return <MaterialAlert {...props} ref={ref} />;
+});
 
 export default AlertBase;

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -1,7 +1,7 @@
 const publicRuntimeConfig =
     process.env.NODE_ENV === "development"
         ? {
-              API_ROOT_URL: "http://localhost:4000/api",
+              API_ROOT_URL: "http://localhost:4000",
               REACT_APP_HASURA_END_POINT: "http://localhost:8080/v1/graphql",
               REACT_APP_HASURA_ADMIN_SECRET: process.env.REACT_APP_HASURA_ADMIN_SECRET || "",
           }

--- a/src/theme/replyTheme.ts
+++ b/src/theme/replyTheme.ts
@@ -1,4 +1,4 @@
-import { createMuiTheme, ThemeOptions } from "@material-ui/core";
+import { unstable_createMuiStrictModeTheme, ThemeOptions } from "@material-ui/core";
 import createBreakpoint from "@material-ui/core/styles/createBreakpoints";
 import { PaletteOptions } from "@material-ui/core/styles/createPalette";
 
@@ -170,5 +170,5 @@ const themeObject: Readonly<ThemeOptions> = {
     },
 };
 
-const replyTheme = createMuiTheme(themeObject);
+const replyTheme = unstable_createMuiStrictModeTheme(themeObject);
 export default replyTheme;


### PR DESCRIPTION
- Generates a theme that reduces the amount of warnings inside React.StrictMode like Warning: findDOMNode is deprecated in StrictMode.
- Document of Mui: https://material-ui.com/customization/theming/#unstable-createmuistrictmodetheme-options-args-theme
- Not using it in production mode 